### PR TITLE
feat(modal): unmount on close, restyling hooks, and dialog a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,24 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2026-07-04
+## [0.2.2] - 2026-07-03
+
+### Added
+
+- `Modal`: `$hideCloseButton` prop to omit the built-in close button
+- `Modal`: `className` passthrough on the overlay root, enabling `styled(Modal)` restyling; inner parts expose stable class hooks (`.modal-inner`, `.modal-close`, `.modal-title`, `.modal-content`)
+- `Modal`: `role="dialog"`, `aria-modal="true"`, and `aria-label` (from `$title`) on the dialog surface
+
+### Changed
+
+- **Breaking-ish:** `Modal` now unmounts its children once the exit animation finishes instead of keeping them mounted (hidden) while closed. Children such as forms reset their state between openings. The enter/exit motion is unchanged visually (fade + 40px rise) but is now driven by keyframes instead of transitions
+- `useOnClickOutside` subscribes its document listener once per mount (latest-ref pattern) instead of re-subscribing whenever callers pass inline ref arrays or callbacks
+
+### Fixed
+
+- `useOnClickOutside` ignores unattached (null) refs instead of suppressing the callback entirely when any ref in the array is not mounted
+
+## [0.2.1] - 2026-07-03
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cherry-styled-components",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Cherry is a design system for the modern web. Designed in Figma, built in React using Typescript.",
   "private": false,
   "type": "module",

--- a/src/lib/modal.tsx
+++ b/src/lib/modal.tsx
@@ -3,10 +3,11 @@ import React, {
   useCallback,
   useEffect,
   useRef,
+  useState,
   useSyncExternalStore,
 } from "react";
 import { createPortal } from "react-dom";
-import styled, { css } from "styled-components";
+import styled, { css, keyframes } from "styled-components";
 import { rgba } from "polished";
 
 import { Icon } from "./icon";
@@ -19,6 +20,11 @@ export interface ModalProps {
   $onClose: () => void;
   $title?: string;
   $width?: number;
+  $hideCloseButton?: boolean;
+  /** Enables restyling via styled(Modal); applied to the overlay root. The
+      inner parts expose class hooks: .modal-inner, .modal-close, .modal-title,
+      .modal-content. */
+  className?: string;
 }
 
 // Hydration-safe client detection: returns the server value (false) during the
@@ -34,8 +40,32 @@ function useIsClient() {
   );
 }
 
+// The modal mounts on open and unmounts once the exit animation finishes, so
+// closed modals keep nothing in the DOM and children (e.g. forms) reset their
+// state between openings. Keyframes (rather than transitions) make the enter
+// motion play on mount and give the exit a definite end event to unmount on.
+const overlayFadeIn = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
+const overlayFadeOut = keyframes`
+  from { opacity: 1; }
+  to { opacity: 0; }
+`;
+
+const innerRiseIn = keyframes`
+  from { transform: translateY(40px); }
+  to { transform: translateY(0); }
+`;
+
+const innerSinkOut = keyframes`
+  from { transform: translateY(0); }
+  to { transform: translateY(40px); }
+`;
+
 const StyledModal = styled.div<{
-  $isOpen: boolean;
+  $isClosing: boolean;
   $width?: number;
   theme: Theme;
 }>`
@@ -49,15 +79,14 @@ const StyledModal = styled.div<{
   justify-content: center;
   align-items: center;
   z-index: 1010;
-  pointer-events: none;
-  opacity: 0;
-  transition: all 0.3s ease;
+  animation: ${({ $isClosing }) =>
+    $isClosing ? overlayFadeOut : overlayFadeIn}
+    0.3s ease both;
 
-  ${({ $isOpen }) =>
-    $isOpen &&
+  ${({ $isClosing }) =>
+    $isClosing &&
     css`
-      opacity: 1;
-      pointer-events: all;
+      pointer-events: none;
     `}
 
   & .modal-inner {
@@ -68,14 +97,8 @@ const StyledModal = styled.div<{
     width: 100%;
     margin: auto;
     position: relative;
-    transform: translateY(40px);
-    transition: all 0.3s ease;
-
-    ${({ $isOpen }) =>
-      $isOpen &&
-      css`
-        transform: translateY(0);
-      `}
+    animation: ${({ $isClosing }) => ($isClosing ? innerSinkOut : innerRiseIn)}
+      0.3s ease both;
 
     ${mq("lg")} {
       max-width: 500px;
@@ -140,10 +163,32 @@ const StyledModalContent = styled.div<{ theme: Theme }>`
   }
 `;
 
-function Modal({ children, $isOpen, $onClose, $title, $width }: ModalProps) {
+function Modal({
+  children,
+  $isOpen,
+  $onClose,
+  $title,
+  $width,
+  $hideCloseButton,
+  className,
+}: ModalProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const elmRef = useRef<HTMLSpanElement>(null);
   const isClient = useIsClient();
+
+  // Stays true while the exit animation plays so the DOM isn't removed until
+  // the animation completes. It flips to false only in the onAnimationEnd
+  // handler (an event callback, not an effect), which satisfies React 19
+  // lint rules.
+  const [shouldRender, setShouldRender] = useState($isOpen);
+
+  // When $isOpen goes false -> true, render immediately. This runs during
+  // render (not in an effect) and only reads props/state, which is safe.
+  if ($isOpen && !shouldRender) {
+    setShouldRender(true);
+  }
+
+  const isClosing = !$isOpen && shouldRender;
 
   const closeModal = useCallback(() => {
     $onClose();
@@ -164,27 +209,58 @@ function Modal({ children, $isOpen, $onClose, $title, $width }: ModalProps) {
 
   useOnClickOutside([elmRef, wrapperRef], $isOpen ? closeModal : () => {});
 
+  const handleAnimationEnd = useCallback(
+    (event: React.AnimationEvent<HTMLDivElement>) => {
+      // Only the overlay's own fade marks the end of the exit; ignore the
+      // bubbled animation events from .modal-inner.
+      if (event.target !== event.currentTarget) return;
+      if (!$isOpen) {
+        setShouldRender(false);
+      }
+    },
+    [$isOpen],
+  );
+
   // Portals are client-only; render nothing on the server and during the first
-  // client render so hydration matches, then portal once on the client.
-  if (!isClient) return null;
+  // client render so hydration matches, then portal once on the client. While
+  // fully closed, render nothing at all so children unmount and reset their
+  // state between openings.
+  if (!isClient || !shouldRender) return null;
 
   // Render into document.body so the fixed-position overlay is lifted out of
   // any transformed/overflow-clipped ancestor and always sits on top.
   return createPortal(
-    <StyledModal $isOpen={$isOpen} $width={$width}>
-      <div className="modal-inner" ref={wrapperRef}>
-        <span ref={elmRef}>
-          <StyledModalClose
-            $size="small"
-            onClick={closeModal}
-            className="modal-close"
-            aria-label="Close Modal"
-          >
-            <Icon name="X" />
-          </StyledModalClose>
-        </span>
-        {$title && <StyledModalTitle>{$title}</StyledModalTitle>}
-        <StyledModalContent>{children}</StyledModalContent>
+    <StyledModal
+      $isClosing={isClosing}
+      $width={$width}
+      className={className}
+      onAnimationEnd={handleAnimationEnd}
+    >
+      <div
+        className="modal-inner"
+        ref={wrapperRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={$title}
+      >
+        {!$hideCloseButton && (
+          <span ref={elmRef}>
+            <StyledModalClose
+              $size="small"
+              onClick={closeModal}
+              className="modal-close"
+              aria-label="Close Modal"
+            >
+              <Icon name="X" />
+            </StyledModalClose>
+          </span>
+        )}
+        {$title && (
+          <StyledModalTitle className="modal-title">{$title}</StyledModalTitle>
+        )}
+        <StyledModalContent className="modal-content">
+          {children}
+        </StyledModalContent>
       </div>
     </StyledModal>,
     document.body,

--- a/src/lib/utils/use-on-click-outside.tsx
+++ b/src/lib/utils/use-on-click-outside.tsx
@@ -1,20 +1,27 @@
 "use client";
-import { RefObject, useEffect } from "react";
+import { RefObject, useEffect, useRef } from "react";
 
 export function useOnClickOutside(
   refs: RefObject<HTMLElement | null>[],
   cb: () => void,
 ) {
+  // Callers typically pass inline arrays and callbacks, so keep the latest
+  // values in a ref and subscribe to the document only once per mount.
+  const latest = useRef({ refs, cb });
+
+  useEffect(() => {
+    latest.current = { refs, cb };
+  });
+
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
+      const { refs, cb } = latest.current;
+      // Unattached refs are ignored: a click counts as outside unless it
+      // lands inside a currently mounted ref target.
       if (
-        refs &&
-        refs
-          .map(
-            (ref) =>
-              ref && ref.current && ref.current.contains(event.target as Node),
-          )
-          .every((i) => i === false)
+        refs.every(
+          (ref) => !ref.current || !ref.current.contains(event.target as Node),
+        )
       ) {
         cb();
       }
@@ -23,5 +30,5 @@ export function useOnClickOutside(
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [refs, cb]);
+  }, []);
 }


### PR DESCRIPTION
## Summary

Release prep for 0.2.2.

### Modal
- Unmounts its children once the exit animation finishes instead of keeping them mounted (hidden) while closed, so children such as forms reset their state between openings. The enter/exit motion is visually unchanged (fade + 40px rise) but is now driven by keyframes instead of transitions
- New `$hideCloseButton` prop to omit the built-in close button
- `className` passthrough on the overlay root, enabling `styled(Modal)` restyling; inner parts expose stable class hooks (`.modal-inner`, `.modal-close`, `.modal-title`, `.modal-content`)
- `role="dialog"`, `aria-modal="true"`, and `aria-label` (from `$title`) on the dialog surface

### useOnClickOutside
- Subscribes its document listener once per mount (latest-ref pattern) instead of re-subscribing whenever callers pass inline ref arrays or callbacks
- Ignores unattached (null) refs instead of suppressing the callback entirely when any ref in the array is not mounted

### Release
- Version bump 0.2.1 -> 0.2.2
- CHANGELOG entry for 0.2.2, plus a date typo fix on the 0.2.1 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)