### PR TITLE
feat: add Spinner loading indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The route is handled in `src/main.tsx` and the previews live in `src/preview.tsx
 | `modal`            | Modal, already open on a backdrop                      |
 | `password`         | Password field with label and placeholder              |
 | `prose`            | Markdown-style content with Cherry typography          |
+| `spinner`          | Rotating loading indicator in three sizes              |
 | `radio`            | Checked radio button                                   |
 | `range`            | Range slider                                           |
 | `select`           | Select with label                                      |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import {
   Range,
   Select,
   Space,
+  Spinner,
   styledBlockquote,
   styledCode,
   styledH2,
@@ -925,6 +926,22 @@ function App() {
             <Tier label="Small">
               <IconButtonTier size="small" />
             </Tier>
+          </Section>
+
+          <StyledDivider />
+
+          <Section
+            title="Spinner"
+            note="The shared loading indicator: a rotating lucide icon that sits still under prefers-reduced-motion. Any icon and size can stand in."
+          >
+            <Box $padding={20}>
+              <Flex $gap={28} $alignItems="center">
+                <Spinner size={16} />
+                <Spinner />
+                <Spinner size={32} />
+                <Spinner name="Loader" size={32} />
+              </Flex>
+            </Box>
           </Section>
 
           <StyledDivider />

--- a/src/lib/chat-input.tsx
+++ b/src/lib/chat-input.tsx
@@ -12,6 +12,7 @@ import styled, { createGlobalStyle, css, keyframes } from "styled-components";
 import { Button } from "./button";
 import { ChatContext } from "./chat-provider";
 import { Icon } from "./icon";
+import { Spinner } from "./spinner";
 import { Theme, alpha, formElementHeightStyles } from "./utils";
 
 export interface ChatInputProps extends Omit<
@@ -109,15 +110,6 @@ const sparkleFloat = keyframes`
   }
 `;
 
-const spin = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-`;
-
 const conicStops = (colors: string[]) => [...colors, colors[0]].join(", ");
 
 const StyledChatForm = styled.form<{ theme: Theme }>`
@@ -130,14 +122,6 @@ const StyledChatForm = styled.form<{ theme: Theme }>`
   width: 100%;
   flex-shrink: 0;
   border-top: solid 1px ${({ theme }) => theme.colors.grayLight};
-
-  & .chat-send-loading {
-    animation: ${spin} 1s linear infinite;
-
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
-    }
-  }
 `;
 
 const StyledInputWrapper = styled.div<{
@@ -395,12 +379,17 @@ const StyledSendButton = styled(Button)`
   min-height: 0;
   position: relative;
 
-  & svg {
+  /* inset + margin centering rather than a translate transform: the Spinner
+     animates transform to rotate, which would overwrite the translate and
+     send the icon orbiting around the button's corner. The .lucide selector
+     is needed to outrank buttonStyles' "& .lucide { margin: auto 0 }", which
+     would otherwise zero the horizontal margin and pin the icon left. */
+  & svg,
+  & .lucide {
     transition: none;
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    inset: 0;
+    margin: auto;
   }
 `;
 
@@ -556,11 +545,7 @@ function LocalChatInput(
         disabled={loading || !hasContent}
         aria-label={loading ? "Loading response" : "Submit question"}
       >
-        {loading ? (
-          <Icon name="LoaderCircle" className="chat-send-loading" />
-        ) : (
-          <Icon name="ArrowUp" />
-        )}
+        {loading ? <Spinner /> : <Icon name="ArrowUp" />}
       </StyledSendButton>
     </StyledChatForm>
   );

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -30,6 +30,7 @@ export * from "./prose";
 export * from "./range";
 export * from "./select";
 export * from "./space";
+export * from "./spinner";
 export * from "./tabs";
 export * from "./textarea";
 export * from "./theme-toggle";

--- a/src/lib/spinner.tsx
+++ b/src/lib/spinner.tsx
@@ -1,0 +1,41 @@
+"use client";
+import styled, { keyframes } from "styled-components";
+
+import { Icon, IconProps } from "./icon";
+
+export interface SpinnerProps {
+  /** Lucide icon to rotate. */
+  name?: IconProps;
+  color?: string;
+  size?: number;
+  className?: string;
+  "aria-label"?: string;
+}
+
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const StyledSpinner = styled(Icon)`
+  /* The icon strokes with currentColor; resolve it from the theme rather
+     than inheritance so the spinner stays visible on either mode's surface
+     (inherited page color does not flip with the theme object). An explicit
+     color prop still wins - it sets the stroke attribute directly. */
+  color: ${({ theme }) => theme.colors.dark};
+  animation: ${spin} 1s linear infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`;
+
+const Spinner = ({ name = "LoaderCircle", ...props }: SpinnerProps) => (
+  <StyledSpinner name={name} {...props} />
+);
+
+export { Spinner };

--- a/src/preview.tsx
+++ b/src/preview.tsx
@@ -28,6 +28,7 @@ import {
   Prose,
   Range,
   Select,
+  Spinner,
   TabContent,
   Tabs,
   Textarea,
@@ -500,6 +501,13 @@ const previews: Record<string, React.ReactNode> = {
     <Select $fullWidth $label="Select" id="select-preview">
       <option>Select</option>
     </Select>
+  ),
+  spinner: (
+    <Flex $gap={28} $alignItems="center">
+      <Spinner size={16} />
+      <Spinner />
+      <Spinner size={32} />
+    </Flex>
   ),
   tabs: (
     <Tabs>


### PR DESCRIPTION
## Summary

Builds on #5 (chat kit). Adds a shared `Spinner` loading indicator and
adopts it in the chat kit's send button in place of its local spin
implementation.

- `Spinner`: a rotating lucide icon (default `LoaderCircle`), 1s
  linear spin, animation disabled under `prefers-reduced-motion`, and
  a theme-resolved default color (`theme.colors.dark`) so it stays
  visible in dark mode — inherited page color does not flip with the
  theme object, and an explicit `color` prop still wins.
- `chat-input.tsx`: send button's loading state now uses the shared
  `Spinner` instead of a local spin keyframes + className approach.
  Icon centering switched to inset+margin, since the Spinner's rotate
  animation conflicts with a translate transform.
- Barrel export, demo section (three sizes + alternate icon), preview
  route, and README preview table entry.

Since this branch is stacked on `feat/chat-kit`, the diff view here
should only show the spinner-related delta.

## Test plan

- [x] `/preview/spinner` renders and animates all three spinners
- [x] Dark mode shows white spinners on the dark surface, light mode
      black (verified via computed color)
- [x] Typecheck clean for lib/demo (only pre-existing `src/main.tsx`
      errors remain)
- [x] Prettier formatting applied